### PR TITLE
Alternative way of scaling the data before simple pca

### DIFF
--- a/source/PcAux/R/helperFunctions.R
+++ b/source/PcAux/R/helperFunctions.R
@@ -205,10 +205,7 @@ simplePca <- function(map, lv, parse, scale = TRUE)
 {
     ## Scale the raw data:
     if(scale) {
-        for(i in 1 : ncol(map$data)) {
-            map$data[ , i] <-
-                (map$data[ , i] - mean(map$data[ , i])) / sd(map$data[ , i])
-        }
+        map$data[] <- scale(map$data)
     }
 
     ## Get the eigen decomposition

--- a/source/PcAux/R/helperFunctions.R
+++ b/source/PcAux/R/helperFunctions.R
@@ -205,7 +205,8 @@ simplePca <- function(map, lv, parse, scale = TRUE)
 {
     ## Scale the raw data:
     if(scale) {
-        map$data[] <- scale(map$data)
+        map$data[] <- lapply(X   = map$data,
+                             FUN = function(x) (x - mean(x))/sd(x))
     }
 
     ## Get the eigen decomposition


### PR DESCRIPTION
I think this way of scaling the data might simplify this function even further; I did some tests and this option seems the most plausible. `scale` is a fairly simple and optimized function but it coerces your data to a matrix, though the `[]` should fix that. 